### PR TITLE
Implementation of system control tray option

### DIFF
--- a/build/Xcode/EnergyBar.xcodeproj/project.pbxproj
+++ b/build/Xcode/EnergyBar.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		3CFECA122122611F00BB58E9 /* LoginItem.c in Sources */ = {isa = PBXBuildFile; fileRef = 3CFECA102122611F00BB58E9 /* LoginItem.c */; };
 		405B467A219A3CCA0006DC16 /* LockWidget.m in Sources */ = {isa = PBXBuildFile; fileRef = 405B4678219A3CCA0006DC16 /* LockWidget.m */; };
 		405B467C219A3D2D0006DC16 /* login.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 405B467B219A3D2D0006DC16 /* login.framework */; };
+		50DD6DFE21D26AEC007697A1 /* DFRFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50DD6DFD21D26AEC007697A1 /* DFRFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -142,6 +143,7 @@
 		405B4678219A3CCA0006DC16 /* LockWidget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LockWidget.m; sourceTree = "<group>"; };
 		405B4679219A3CCA0006DC16 /* LockWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LockWidget.h; sourceTree = "<group>"; };
 		405B467B219A3D2D0006DC16 /* login.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = login.framework; path = ../../../../../../System/Library/PrivateFrameworks/login.framework; sourceTree = "<group>"; };
+		50DD6DFD21D26AEC007697A1 /* DFRFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DFRFoundation.framework; path = ../../../../../../System/Library/PrivateFrameworks/DFRFoundation.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +151,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50DD6DFE21D26AEC007697A1 /* DFRFoundation.framework in Frameworks */,
 				405B467C219A3D2D0006DC16 /* login.framework in Frameworks */,
 				3C83DB48211D851700FC2F53 /* CoreBrightness.framework in Frameworks */,
 				3CE58CE72162B79700633D5D /* DisplayServices.framework in Frameworks */,
@@ -282,6 +285,7 @@
 		3C83DB46211D851600FC2F53 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				50DD6DFD21D26AEC007697A1 /* DFRFoundation.framework */,
 				405B467B219A3D2D0006DC16 /* login.framework */,
 				3C83DB47211D851700FC2F53 /* CoreBrightness.framework */,
 				3CE58CE62162B79700633D5D /* DisplayServices.framework */,

--- a/rsc/Base.lproj/MainWindow.xib
+++ b/rsc/Base.lproj/MainWindow.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaDFRPlugin" version="14215.3"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaDFRPlugin" version="14460.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="the Touch Bar" minToolsVersion="8.1" minSystemVersion="10.12.2" requiredIntegratedClassName="NSTouchBar"/>
     </dependencies>
@@ -505,11 +505,11 @@
             <point key="canvasLocation" x="31" y="-1362"/>
         </touchBar>
         <customView id="LNX-xt-gFC">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="373"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="407"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RI6-LC-Dn0">
-                    <rect key="frame" x="18" y="334" width="142" height="17"/>
+                    <rect key="frame" x="18" y="368" width="142" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Applications Folder:" id="we4-MN-ZoZ">
                         <font key="font" metaFont="system"/>
@@ -517,8 +517,17 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="soe-7k-cyu">
+                    <rect key="frame" x="18" y="70" width="142" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Touchbar Options:" id="ImS-pQ-oCf">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <pathControl verticalHuggingPriority="750" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nd5-hn-yED">
-                    <rect key="frame" x="163" y="329" width="300" height="26"/>
+                    <rect key="frame" x="163" y="363" width="300" height="26"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <pathCell key="cell" selectable="YES" editable="YES" alignment="left" pathStyle="popUp" id="iGa-4q-LTE">
                         <font key="font" metaFont="system"/>
@@ -541,7 +550,7 @@
                     </connections>
                 </pathControl>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CXO-38-BKx">
-                    <rect key="frame" x="164" y="241" width="298" height="84"/>
+                    <rect key="frame" x="164" y="275" width="298" height="84"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="justified" id="1ol-1B-y4l">
                         <font key="font" metaFont="smallSystem"/>
@@ -553,7 +562,7 @@ In general the folder should contain application aliases. The order of the folde
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FlB-cq-KEg">
-                    <rect key="frame" x="160" y="193" width="153" height="32"/>
+                    <rect key="frame" x="160" y="227" width="153" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="From macOS Dock" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="PfM-cZ-x9j">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -564,7 +573,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rgY-4i-8rq">
-                    <rect key="frame" x="313" y="193" width="153" height="32"/>
+                    <rect key="frame" x="313" y="227" width="153" height="32"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="push" title="Show Folder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="YqK-L0-qea">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -575,7 +584,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a2a-cX-kjk">
-                    <rect key="frame" x="164" y="164" width="182" height="18"/>
+                    <rect key="frame" x="164" y="198" width="182" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show running applications" bezelStyle="regularSquare" imagePosition="left" inset="2" id="F3l-pF-4z4">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -586,8 +595,20 @@ In general the folder should contain application aliases. The order of the folde
                         <binding destination="pJh-SC-QEV" name="value" keyPath="values.showsRunningApps" id="Grg-py-OEW"/>
                     </connections>
                 </button>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lxC-eX-4QQ">
+                    <rect key="frame" x="164" y="69" width="155" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" title="Show system controls" bezelStyle="regularSquare" imagePosition="left" inset="2" id="wfZ-Sp-Kj0">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="touchbarSettingsChange:" target="Voe-Tx-rLC" id="vtQ-iY-iBv"/>
+                        <binding destination="pJh-SC-QEV" name="value" keyPath="values.showsSystemControl" id="rWg-yw-IbH"/>
+                    </connections>
+                </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aqA-xy-O2O">
-                    <rect key="frame" x="164" y="144" width="179" height="18"/>
+                    <rect key="frame" x="164" y="178" width="179" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Open folders in Touch Bar" bezelStyle="regularSquare" imagePosition="left" inset="2" id="MUe-xM-LBQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -599,7 +620,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uDG-IA-Ui4">
-                    <rect key="frame" x="164" y="124" width="90" height="18"/>
+                    <rect key="frame" x="164" y="158" width="90" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show trash" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JrQ-QJ-ade">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -611,7 +632,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DjH-vU-Mfw">
-                    <rect key="frame" x="164" y="104" width="212" height="18"/>
+                    <rect key="frame" x="164" y="138" width="212" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Accept clicks and dragged files" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZwQ-ex-YBc">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -623,7 +644,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FJg-AN-1Yz">
-                    <rect key="frame" x="164" y="70" width="298" height="28"/>
+                    <rect key="frame" x="164" y="104" width="298" height="28"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="justified" title="If enabled you can use the mouse to click items on the EnergyBar Dock or drag files to it." id="e6r-G4-i53">
                         <font key="font" metaFont="smallSystem"/>
@@ -632,6 +653,10 @@ In general the folder should contain application aliases. The order of the folde
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Odg-GT-X9V">
+                    <rect key="frame" x="12" y="93" width="456" height="5"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                </box>
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="QUe-cG-zRT">
                     <rect key="frame" x="12" y="59" width="456" height="5"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                 </box>
@@ -647,7 +672,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="85" y="-793.5"/>
+            <point key="canvasLocation" x="85" y="-776.5"/>
         </customView>
         <customView id="th2-os-EZ4">
             <rect key="frame" x="0.0" y="0.0" width="480" height="178"/>
@@ -766,7 +791,7 @@ In general the folder should contain application aliases. The order of the folde
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="85" y="-473"/>
+            <point key="canvasLocation" x="85" y="-412"/>
         </customView>
         <customView id="oZG-ix-yVe">
             <rect key="frame" x="0.0" y="0.0" width="480" height="380"/>
@@ -901,14 +926,14 @@ Click to acknowledge.</string>
                     </connections>
                 </button>
             </subviews>
-            <point key="canvasLocation" x="85" y="-156"/>
+            <point key="canvasLocation" x="85" y="-77"/>
         </customView>
     </objects>
     <resources>
         <image name="AppIcon" width="128" height="128"/>
-        <image name="NSAdvanced" width="128" height="128"/>
-        <image name="NSCaution" width="128" height="128"/>
-        <image name="NSPreferencesGeneral" width="128" height="128"/>
+        <image name="NSAdvanced" width="32" height="32"/>
+        <image name="NSCaution" width="32" height="32"/>
+        <image name="NSPreferencesGeneral" width="32" height="32"/>
         <image name="NSStatusPartiallyAvailable" width="16" height="16"/>
         <image name="Widgets" width="32" height="32"/>
     </resources>

--- a/rsc/defaults.plist
+++ b/rsc/defaults.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>showsSystemControl</key>
+	<false/>
 	<key>automaticUpdates</key>
 	<false/>
 	<key>defaultApps</key>

--- a/src/System/NSTouchBar+SystemModal.h
+++ b/src/System/NSTouchBar+SystemModal.h
@@ -13,9 +13,18 @@
 
 #import <Cocoa/Cocoa.h>
 
+extern void DFRElementSetControlStripPresenceForIdentifier(NSTouchBarItemIdentifier, BOOL);
+extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
+
 @interface NSTouchBar (SystemModal)
 + (BOOL)presentSystemModal:(NSTouchBar *)touchBar
     placement:(long long)placement
     systemTrayItemIdentifier:(NSTouchBarItemIdentifier)identifier;
 + (void)dismissSystemModal:(NSTouchBar *)touchBar;
++ (void)minimizeSystemModal:(NSTouchBar *)touchBar;
+@end
+
+@interface NSTouchBarItem ()
++ (void)addSystemTrayItem:(NSTouchBarItem *)item;
++ (void)removeSystemTrayItem:(NSTouchBarItem *)item;
 @end

--- a/src/System/NSTouchBar+SystemModal.m
+++ b/src/System/NSTouchBar+SystemModal.m
@@ -33,11 +33,6 @@
 + (void)minimizeSystemModalTouchBar:(NSTouchBar *)touchBar;
 @end
 
-@interface NSTouchBarItem ()
-+ (void)addSystemTrayItem:(NSTouchBarItem *)item;
-+ (void)removeSystemTrayItem:(NSTouchBarItem *)item;
-@end
-
 @implementation NSTouchBar (SystemModal)
 + (BOOL)presentSystemModal:(NSTouchBar *)touchBar
     placement:(long long)placement
@@ -78,6 +73,22 @@
     {
         [NSTouchBar
             dismissSystemModalTouchBar:touchBar];
+    }
+}
+
++ (void)minimizeSystemModal:(NSTouchBar *)touchBar
+{
+    if ([NSTouchBar respondsToSelector:
+         @selector(minimizeSystemModalFunctionBar:)])
+    {
+        [NSTouchBar
+         minimizeSystemModalFunctionBar:touchBar];
+    }
+    else if ([NSTouchBar respondsToSelector:
+              @selector(minimizeSystemModalTouchBar:)])
+    {
+        [NSTouchBar
+         minimizeSystemModalTouchBar:touchBar];
     }
 }
 @end

--- a/src/TouchBarController.h
+++ b/src/TouchBarController.h
@@ -15,11 +15,13 @@
 
 @interface TouchBarController : NSObject
 + (id)controllerWithNibNamed:(NSString *)name;
+- (BOOL)isPresented;
 - (BOOL)present;
 - (BOOL)presentWithPlacement:(NSInteger)placement;
 - (void)dismiss;
+- (void)minimize;
 - (IBAction)close:(id)sender;
 - (IBAction)customize:(id)sender;
 @property (retain) IBOutlet NSTouchBar *touchBar;
-@property (assign) BOOL presented;
+@property (assign) NSInteger placement;
 @end

--- a/src/TouchBarController.m
+++ b/src/TouchBarController.m
@@ -14,6 +14,8 @@
 #import "TouchBarController.h"
 #import "NSTouchBar+SystemModal.h"
 
+static const NSTouchBarItemIdentifier kBarIdentifier = @"billziss.energybar";
+
 @implementation TouchBarController
 + (id)controllerWithNibNamed:(NSString *)name
 {
@@ -23,6 +25,8 @@
     if (![[NSBundle mainBundle]
         loadNibNamed:name owner:controller topLevelObjects:&objects])
         return nil;
+    
+    [controller setPlacement:1];
 
     return controller;
 }
@@ -37,31 +41,34 @@
     [super dealloc];
 }
 
+- (BOOL)isPresented
+{
+    return [self.touchBar isVisible];
+}
+
 - (BOOL)present
 {
-    return [self presentWithPlacement:1];
+    return [self presentWithPlacement:self.placement];
 }
 
 - (BOOL)presentWithPlacement:(NSInteger)placement
 {
-    if (self.presented)
-        return NO;
     BOOL res = [NSTouchBar
         presentSystemModal:self.touchBar
         placement:placement
-        systemTrayItemIdentifier:nil];
-    if (res)
-        self.presented = YES;
+        systemTrayItemIdentifier:kBarIdentifier];
     return res;
 }
 
 - (void)dismiss
 {
-    if (!self.presented)
-        return;
     [NSTouchBar
         dismissSystemModal:self.touchBar];
-    self.presented = NO;
+}
+
+- (void)minimize
+{
+    [NSTouchBar minimizeSystemModal:self.touchBar];
 }
 
 - (IBAction)close:(id)sender

--- a/src/Widgets/DockWidget.m
+++ b/src/Widgets/DockWidget.m
@@ -509,7 +509,7 @@ static NSShadow *shadowWithOffset(NSSize shadowOffset)
 {
     [(id)self.prominentView setProminent:NO];
 
-    if (self.folderController.presented ||
+    if ([self.folderController isPresented] ||
         ![[NSUserDefaults standardUserDefaults] boolForKey:@"acceptsDraggedItems"])
         return;
 
@@ -530,7 +530,7 @@ static NSShadow *shadowWithOffset(NSSize shadowOffset)
 {
     [(id)self.prominentView setProminent:NO];
 
-    if (self.folderController.presented ||
+    if ([self.folderController isPresented] ||
         ![[NSUserDefaults standardUserDefaults] boolForKey:@"acceptsDraggedItems"])
         return;
 
@@ -559,7 +559,7 @@ static NSShadow *shadowWithOffset(NSSize shadowOffset)
     DockWidgetView *view = self.view;
     NSDragOperation res = NSDragOperationNone;
 
-    if (self.folderController.presented ||
+    if ([self.folderController isPresented] ||
         ![[NSUserDefaults standardUserDefaults] boolForKey:@"acceptsDraggedItems"])
     {
         view.dragTargetView.hidden = YES;
@@ -625,7 +625,7 @@ static NSShadow *shadowWithOffset(NSSize shadowOffset)
     DockWidgetView *view = self.view;
     BOOL res = NO;
 
-    if (self.folderController.presented ||
+    if ([self.folderController isPresented] ||
         ![[NSUserDefaults standardUserDefaults] boolForKey:@"acceptsDraggedItems"])
     {
         view.dragTargetView.hidden = YES;


### PR DESCRIPTION
Add an touchbar option to show the system controls of the normal
touchbar.

This option adds an energybar button to the system controls, which
can be used to expand the energybar into the application space of
the touchbar.

This way it is possible to use the system provided control button and offers a quick way to show the native touchbar controls.